### PR TITLE
Ajout d'un fonction de spread (entity/location)

### DIFF
--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_player.mcfunction
@@ -1,0 +1,5 @@
+execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
+execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=tp] Var2 0
+execute store result entity @s Pos[2] double 0.001 run scoreboard players add @a[tag=tp] Var3 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_player.mcfunction
@@ -1,5 +1,5 @@
-execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
-execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=tp] Var2 0
-execute store result entity @s Pos[2] double 0.001 run scoreboard players add @a[tag=tp] Var3 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=SetLocation] Var2 0
+execute store result entity @s Pos[2] double 0.001 run scoreboard players add @a[tag=SetLocation] Var3 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_x_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_x_player.mcfunction
@@ -1,0 +1,4 @@
+execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_x_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_x_player.mcfunction
@@ -1,4 +1,4 @@
-execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
-execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[0] double 0.001 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=SetLocation,limit=1] Pos[1]
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_y_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_y_player.mcfunction
@@ -1,0 +1,3 @@
+execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_y_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_y_player.mcfunction
@@ -1,3 +1,3 @@
-execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=tp] Var1 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[1] double 0.001 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_z_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_z_player.mcfunction
@@ -1,0 +1,4 @@
+execute store result entity @s Pos[1] double 0.001 run data get entity @a[tag=tp,limit=1] Pos[1]
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var1 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/child/set_z_player.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/child/set_z_player.mcfunction
@@ -1,4 +1,4 @@
-execute store result entity @s Pos[1] double 0.001 run data get entity @a[tag=tp,limit=1] Pos[1]
-execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var1 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[1] double 0.001 run data get entity @a[tag=SetLocation,limit=1] Pos[1]
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/accuracy/10-3/set.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/set.mcfunction
@@ -26,12 +26,10 @@ scoreboard objectives add Var3 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~ ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[0] double 0.001 run scoreboard players get @s Var1
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[1] double 0.001 run scoreboard players get @s Var2
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[2] double 0.001 run scoreboard players get @s Var3
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/accuracy/10-3/child/set_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 0.001 run scoreboard players add @s Var1 0
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 0.001 run scoreboard players add @s Var2 0
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 0.001 run scoreboard players add @s Var3 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/accuracy/10-3/set_x.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/set_x.mcfunction
@@ -24,10 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~ ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[0] double 0.001 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/accuracy/10-3/child/set_x_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 0.001 run scoreboard players add @s Var1 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/accuracy/10-3/set_y.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/set_y.mcfunction
@@ -24,10 +24,9 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~ ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/accuracy/10-3/child/set_y_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 0.001 run scoreboard players add @s Var1 0
+tag @s remove tp
 
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[1] double 0.001 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]

--- a/data/glib/functions/entity/location/accuracy/10-3/set_z.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/set_z.mcfunction
@@ -24,10 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~ ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[2] double 0.001 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/accuracy/10-3/child/set_z_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 0.001 run scoreboard players add @s Var1 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/accuracy/10-3/spread.mcfunction
+++ b/data/glib/functions/entity/location/accuracy/10-3/spread.mcfunction
@@ -1,0 +1,64 @@
+#__________________________________________________
+# INFO     Copyright © 2020 Gunivers.
+
+# Authors: A2va
+# Contributors:
+# MC Version: 1.13
+# Last check:
+
+# Original path: glib:entity/location/spread
+# Documentation: https://project.gunivers.net/projects/gunivers-lib/wiki/entity
+# Note: Spread an entity based on CenterX, CenterZ and Radius scores
+
+#__________________________________________________
+# PARAMETERS
+#Var4: CenterX
+#Var5: CenterZ 
+#Var6: Radius
+#__________________________________________________
+# INIT
+scoreboard objectives add Res1 dummy
+scoreboard objectives add Var1 dummy
+scoreboard objectives add Var2 dummy
+scoreboard objectives add Var3 dummy
+
+scoreboard objectives add Var4 dummy
+scoreboard objectives add Var5 dummy
+scoreboard objectives add Var6 dummy
+scoreboard objectives add Var7 dummy
+
+#__________________________________________________
+# CONFIG
+
+#__________________________________________________
+# CODE
+scoreboard players operation @s Var7 = @s Var6
+scoreboard players operation @s Var7 *= 2 Constant
+scoreboard players operation @s Var7 += 1 Constant
+
+#Random
+function glib:math/random
+scoreboard players operation @s Res1 %= @s Var7 
+
+scoreboard players set @s Var1 0
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var1 -= @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var1 /= 2 Constant
+execute if score @s Res1 <= @s Var6 run scoreboard players operation @s Var1 = @s Res1
+
+scoreboard players operation @s Var1 += @s Var4
+
+#Random
+function glib:math/random
+scoreboard players operation @s Res1 %= @s Var7 
+
+scoreboard players set @s Var3 0
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var3 -= @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var3 /= 2 Constant
+execute if score @s Res1 <= @s Var6 run scoreboard players operation @s Var3 = @s Res1
+
+scoreboard players operation @s Var3 += @s Var5
+
+execute store result score @s Var2 run data get entity @s Pos[1] 1
+
+function glib:entity/location/accuracy/10-3/set
+

--- a/data/glib/functions/entity/location/child/set_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_player.mcfunction
@@ -1,0 +1,5 @@
+execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=tp] Var1 0
+execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=tp] Var2 0
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var3 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/child/set_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_player.mcfunction
@@ -1,5 +1,5 @@
-execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=tp] Var1 0
-execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=tp] Var2 0
-execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var3 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=SetLocation] Var2 0
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=SetLocation] Var3 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/child/set_x_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_x_player.mcfunction
@@ -1,0 +1,4 @@
+execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=tp] Var1 0
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/child/set_x_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_x_player.mcfunction
@@ -1,4 +1,4 @@
-execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=tp] Var1 0
-execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[0] double 1 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=SetLocation,limit=1] Pos[1]
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/child/set_y_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_y_player.mcfunction
@@ -1,3 +1,3 @@
-execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=tp] Var1 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/child/set_y_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_y_player.mcfunction
@@ -1,0 +1,3 @@
+execute store result entity @s Pos[1] double 1 run scoreboard players add @a[tag=tp] Var1 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/child/set_z_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_z_player.mcfunction
@@ -1,4 +1,4 @@
-execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
-execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var1 0
-execute at @s run tp @a[tag=tp] ~ ~ ~
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=SetLocation,limit=1] Pos[1]
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=SetLocation] Var1 0
+execute at @s run tp @a[tag=SetLocation] ~ ~ ~
 kill @s

--- a/data/glib/functions/entity/location/child/set_z_player.mcfunction
+++ b/data/glib/functions/entity/location/child/set_z_player.mcfunction
@@ -1,0 +1,4 @@
+execute store result entity @s Pos[1] double 1 run data get entity @a[tag=tp,limit=1] Pos[1]
+execute store result entity @s Pos[2] double 1 run scoreboard players add @a[tag=tp] Var1 0
+execute at @s run tp @a[tag=tp] ~ ~ ~
+kill @s

--- a/data/glib/functions/entity/location/set.mcfunction
+++ b/data/glib/functions/entity/location/set.mcfunction
@@ -26,12 +26,10 @@ scoreboard objectives add Var3 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[0] double 1 run scoreboard players get @s Var1
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[1] double 1 run scoreboard players get @s Var2
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[2] double 1 run scoreboard players get @s Var3
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 1 run scoreboard players add @s Var1 0
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 1 run scoreboard players add @s Var2 0
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 1 run scoreboard players add @s Var3 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/set.mcfunction
+++ b/data/glib/functions/entity/location/set.mcfunction
@@ -26,10 +26,10 @@ scoreboard objectives add Var3 dummy
 #__________________________________________________
 # CODE
 
-tag @s add tp
+tag @s add SetLocation
 execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
 execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_player
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 1 run scoreboard players add @s Var1 0
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 1 run scoreboard players add @s Var2 0
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 1 run scoreboard players add @s Var3 0
-tag @s remove tp
+tag @s remove SetLocation

--- a/data/glib/functions/entity/location/set_x.mcfunction
+++ b/data/glib/functions/entity/location/set_x.mcfunction
@@ -24,10 +24,9 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_x_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 1 run scoreboard players add @s Var1 0
+tag @s remove tp
 
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[0] double 1 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]

--- a/data/glib/functions/entity/location/set_x.mcfunction
+++ b/data/glib/functions/entity/location/set_x.mcfunction
@@ -24,9 +24,9 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-tag @s add tp
+tag @s add SetLocation
 execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
 execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_x_player
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[0] double 1 run scoreboard players add @s Var1 0
-tag @s remove tp
+tag @s remove SetLocation
 

--- a/data/glib/functions/entity/location/set_y.mcfunction
+++ b/data/glib/functions/entity/location/set_y.mcfunction
@@ -24,10 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[1] double 1 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_y_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 1 run scoreboard players add @s Var1 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/set_y.mcfunction
+++ b/data/glib/functions/entity/location/set_y.mcfunction
@@ -24,8 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-tag @s add tp
+tag @s add SetLocation
 execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
 execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_y_player
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[1] double 1 run scoreboard players add @s Var1 0
-tag @s remove tp
+tag @s remove SetLocation

--- a/data/glib/functions/entity/location/set_z.mcfunction
+++ b/data/glib/functions/entity/location/set_z.mcfunction
@@ -24,8 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-tag @s add tp
+tag @s add SetLocation
 execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
 execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_z_player
 execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 1 run scoreboard players add @s Var1 0
-tag @s remove tp
+tag @s remove SetLocation

--- a/data/glib/functions/entity/location/set_z.mcfunction
+++ b/data/glib/functions/entity/location/set_z.mcfunction
@@ -24,10 +24,8 @@ scoreboard objectives add Var1 dummy
 #__________________________________________________
 # CODE
 
-summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
-
-tp @e[type=armor_stand,tag=SetLocation,limit=1] @s
-
-execute store result entity @e[type=armor_stand,tag=SetLocation,limit=1] Pos[2] double 1 run scoreboard players get @s Var1
-tp @s @e[type=armor_stand,tag=SetLocation,limit=1]
-kill @e[type=armor_stand,tag=SetLocation,limit=1]
+tag @s add tp
+execute if entity @s[type=minecraft:player] run summon armor_stand ~ ~200 ~ {Invisible:1,NoGravity:1,Tags:["Glib","SetLocation"]}
+execute if entity @s[type=minecraft:player] as @e[tag=SetLocation,limit=1] run function glib:entity/location/child/set_z_player
+execute if entity @s[type=!minecraft:player] store result entity @s Pos[2] double 1 run scoreboard players add @s Var1 0
+tag @s remove tp

--- a/data/glib/functions/entity/location/spread.mcfunction
+++ b/data/glib/functions/entity/location/spread.mcfunction
@@ -8,7 +8,7 @@
 
 # Original path: glib:entity/location/spreadplayers
 # Documentation: https://project.gunivers.net/projects/gunivers-lib/wiki/entity
-# Note: Return 1 if the entity is in a cave, 0 else.
+# Note: Spread an entity based on CenterX, CenterZ and Radius scores
 
 #__________________________________________________
 # PARAMETERS

--- a/data/glib/functions/entity/location/spread.mcfunction
+++ b/data/glib/functions/entity/location/spread.mcfunction
@@ -1,0 +1,61 @@
+#__________________________________________________
+# INFO     Copyright © 2020 Gunivers.
+
+# Authors: A2va
+# Contributors:
+# MC Version: 1.13
+# Last check:
+
+# Original path: glib:entity/location/spreadplayers
+# Documentation: https://project.gunivers.net/projects/gunivers-lib/wiki/entity
+# Note: Return 1 if the entity is in a cave, 0 else.
+
+#__________________________________________________
+# PARAMETERS
+
+#__________________________________________________
+# INIT
+scoreboard objectives add Res1 dummy
+scoreboard objectives add Var1 dummy
+scoreboard objectives add Var2 dummy
+scoreboard objectives add Var3 dummy
+
+scoreboard objectives add Radius dummy
+scoreboard objectives add Radius2 dummy
+scoreboard objectives add CenterX dummy
+scoreboard objectives add CenterZ dummy
+#__________________________________________________
+# CONFIG
+
+#__________________________________________________
+# CODE
+scoreboard players operation @s Radius2 = @s Radius
+scoreboard players operation @s Radius2 *= 2 Constant
+scoreboard players operation @s Radius2 += 1 Constant
+
+#Random
+function glib:math/random
+scoreboard players operation @s Res1 %= @s Radius2 
+
+scoreboard players set @s Var1 0
+execute if score @s Res1 > @s Radius run scoreboard players operation @s Var1 -= @s Res1
+execute if score @s Res1 > @s Radius run scoreboard players operation @s Var1 /= 2 Constant
+execute if score @s Res1 <= @s Radius run scoreboard players operation @s Var1 = @s Res1
+
+scoreboard players operation @s Var1 += @s CenterX
+
+#Random
+function glib:math/random
+scoreboard players operation @s Res1 %= @s Radius2 
+
+scoreboard players set @s Var3 0
+execute if score @s Res1 > @s Radius run scoreboard players operation @s Var3 -= @s Res1
+execute if score @s Res1 > @s Radius run scoreboard players operation @s Var3 /= 2 Constant
+execute if score @s Res1 <= @s Radius run scoreboard players operation @s Var3 = @s Res1
+
+scoreboard players operation @s Var3 += @s CenterZ
+
+execute store result score @s Var2 run data get entity @s Pos[1] 1
+
+function glib:entity/location/set
+

--- a/data/glib/functions/entity/location/spread.mcfunction
+++ b/data/glib/functions/entity/location/spread.mcfunction
@@ -6,13 +6,15 @@
 # MC Version: 1.13
 # Last check:
 
-# Original path: glib:entity/location/spreadplayers
+# Original path: glib:entity/location/spread
 # Documentation: https://project.gunivers.net/projects/gunivers-lib/wiki/entity
 # Note: Spread an entity based on CenterX, CenterZ and Radius scores
 
 #__________________________________________________
 # PARAMETERS
-
+#Var4: CenterX
+#Var5: CenterZ 
+#Var6: Radius
 #__________________________________________________
 # INIT
 scoreboard objectives add Res1 dummy
@@ -20,40 +22,41 @@ scoreboard objectives add Var1 dummy
 scoreboard objectives add Var2 dummy
 scoreboard objectives add Var3 dummy
 
-scoreboard objectives add Radius dummy
-scoreboard objectives add Radius2 dummy
-scoreboard objectives add CenterX dummy
-scoreboard objectives add CenterZ dummy
+scoreboard objectives add Var4 dummy
+scoreboard objectives add Var5 dummy
+scoreboard objectives add Var6 dummy
+scoreboard objectives add Var7 dummy
+
 #__________________________________________________
 # CONFIG
 
 #__________________________________________________
 # CODE
-scoreboard players operation @s Radius2 = @s Radius
-scoreboard players operation @s Radius2 *= 2 Constant
-scoreboard players operation @s Radius2 += 1 Constant
+scoreboard players operation @s Var7 = @s Var6
+scoreboard players operation @s Var7 *= 2 Constant
+scoreboard players operation @s Var7 += 1 Constant
 
 #Random
 function glib:math/random
-scoreboard players operation @s Res1 %= @s Radius2 
+scoreboard players operation @s Res1 %= @s Var7 
 
 scoreboard players set @s Var1 0
-execute if score @s Res1 > @s Radius run scoreboard players operation @s Var1 -= @s Res1
-execute if score @s Res1 > @s Radius run scoreboard players operation @s Var1 /= 2 Constant
-execute if score @s Res1 <= @s Radius run scoreboard players operation @s Var1 = @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var1 -= @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var1 /= 2 Constant
+execute if score @s Res1 <= @s Var6 run scoreboard players operation @s Var1 = @s Res1
 
-scoreboard players operation @s Var1 += @s CenterX
+scoreboard players operation @s Var1 += @s Var4
 
 #Random
 function glib:math/random
-scoreboard players operation @s Res1 %= @s Radius2 
+scoreboard players operation @s Res1 %= @s Var7 
 
 scoreboard players set @s Var3 0
-execute if score @s Res1 > @s Radius run scoreboard players operation @s Var3 -= @s Res1
-execute if score @s Res1 > @s Radius run scoreboard players operation @s Var3 /= 2 Constant
-execute if score @s Res1 <= @s Radius run scoreboard players operation @s Var3 = @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var3 -= @s Res1
+execute if score @s Res1 > @s Var6 run scoreboard players operation @s Var3 /= 2 Constant
+execute if score @s Res1 <= @s Var6 run scoreboard players operation @s Var3 = @s Res1
 
-scoreboard players operation @s Var3 += @s CenterZ
+scoreboard players operation @s Var3 += @s Var5
 
 execute store result score @s Var2 run data get entity @s Pos[1] 1
 


### PR DESCRIPTION
J'ai ajouté une fonction permettant de tp une entité dans un certain rayon avec un centre x et z. Le résultat ressemble à la fonction spreadplayers de minecraft sauf que je n'ai pas implémenté de distance minimale entre les entités. 

J'ai aussi réécrit les fonctions set (aussi dans location/entity) ainsi que ces mêmes fonctions dans le dossier accuracy/10-3.

